### PR TITLE
Update infiblocks.py

### DIFF
--- a/scripts/infiblocks.py
+++ b/scripts/infiblocks.py
@@ -6,8 +6,6 @@
 from pyspades.contained import WeaponReload, SetTool, PlayerPropertiesV1
 from piqueserver.commands import command
 from pyspades.constants import FALL_KILL, GRENADE_TOOL
-import enet
-import struct
 set_tool = SetTool()
 
 COMMAND_IS_LOUD = False

--- a/scripts/infiblocks.py
+++ b/scripts/infiblocks.py
@@ -25,7 +25,6 @@ def send_player_property_packet(self):
     ammo_clip = self.weapon_object.current_ammo                           
     ammo_reserved = self.weapon_object.current_stock                      
     score = self.kills                                                    
-    subID = 0
                                                                             
     # Corrected packet structure with all 10 items                        
     packet_data = struct.pack(                                            


### PR DESCRIPTION
Introduce player extension packet, which is already a thing in BetterSpades. This sends an update of some player specific numbers, allowing to modify the number of blocks and grenades to what they are. 

This fixes a bug that made scrolling through tools with 0 grenades + refilled blocks kinda weird, to all clients that support this packet or will eventually support it.